### PR TITLE
Tile placement improvements

### DIFF
--- a/game.css
+++ b/game.css
@@ -269,6 +269,13 @@ a.button:active {
 .selectedSpace .gameSpace-overlay {
 	background-color: white;
 }
+.highlightedSpace .gameSpace-overlay {
+	background-color: yellow;
+}
+.selectedSpace.highlightedSpace .gameSpace-overlay {
+	background-color: lightyellow;
+	opacity: .5;
+}
 .tileRack {
 	height: 100%;
 	background: var(--dark);

--- a/src/components/sections/GameBoard.js
+++ b/src/components/sections/GameBoard.js
@@ -346,7 +346,7 @@ class GameBoard extends React.Component {
 				}
 				else {
 					// Swap the pieces
-					this.swapPieces(pieceInfo.fromId,id)
+					this.swapPieces(pieceInfo.fromId,id);
 					return;
 				}
 			}
@@ -419,14 +419,16 @@ class GameBoard extends React.Component {
 				else if (occupantInfo.color == color) {
 					this.props.app.tileSpaces[occupantInfo.rank].setState({remaining: this.props.app.tileSpaces[occupantInfo.rank].remaining+1});
 					this.props.app.tileSpaces[occupantInfo.rank].remaining++;
+					tileSpace.remaining--;
 				}
 			}
-			if (color == playerColor) 
-			{
-				tileSpace.remaining--;
-				app.tileRack.remaining--;
-				if (!app.tileRack.remaining) {
-					app.tileRack.setState({ allPlaced: true });
+			else {
+				if (color == playerColor) {
+					tileSpace.remaining--;
+					app.tileRack.remaining--;
+					if (!app.tileRack.remaining) {
+						app.tileRack.setState({ allPlaced: true });
+					}
 				}
 			}
 			tileSpace.setState({ remaining: tileSpace.remaining });

--- a/src/components/sections/GameBoard.js
+++ b/src/components/sections/GameBoard.js
@@ -102,7 +102,6 @@ class GameBoard extends React.Component {
 		this.placePiece({ rank: rank, color: playerColor, tileSpace: targetSpace }, spaceId, false);
 	}
 	highlightSpace(id) {
-		console.log('highlight',id);
 		this.setState({ highlighted: id });
 	}
 	highlightByKeyboard() {
@@ -299,11 +298,11 @@ class GameBoard extends React.Component {
 		var fromCoords = idToXy(fromId);
 		var toCoords = idToXy(toId);
 		
-		var fromPiece =  (<DragPiece color={fromInfo.color} rank={fromInfo.rank} fromX={toInfo.fromX} fromY={toInfo.fromY} fromId={toId} placed={true} />);
-		var toPiece =  (<DragPiece color={toInfo.color} rank={toInfo.rank} fromX={fromInfo.fromX} fromY={fromInfo.fromY} fromId={fromId} placed={true} />);
+		var fromPiece =  (<DragPiece color={fromInfo.color} rank={fromInfo.rank} fromX={toInfo.fromX} fromY={toInfo.fromY} fromId={toId} placed={true} game={this} />);
+		var toPiece =  (<DragPiece color={toInfo.color} rank={toInfo.rank} fromX={fromInfo.fromX} fromY={fromInfo.fromY} fromId={fromId} placed={true} game={this} />);
 
-		spaces[toId] = this.renderGameSpace(fromCoords.y,fromCoords.x,toId,fromPiece);
-		spaces[fromId] = this.renderGameSpace(toCoords.y,toCoords.x,fromId,toPiece);
+		spaces[toId] = this.renderGameSpace(toCoords.y,toCoords.x,toId,fromPiece);
+		spaces[fromId] = this.renderGameSpace(fromCoords.y,fromCoords.x,fromId,toPiece);
 		
 		this.setState({spaces: spaces});
 		app.saveActiveGame();
@@ -330,14 +329,7 @@ class GameBoard extends React.Component {
 				}
 				else {
 					// Swap the pieces
-					var occupantInfo = spaces[id].props.children.props;
-					var fromPiece =  (<DragPiece color={pieceInfo.color} rank={pieceInfo.rank} fromX={x} fromY={y} fromId={id} placed={true} />);
-					var toPiece =  (<DragPiece color={occupantInfo.color} rank={occupantInfo.rank} fromX={pieceInfo.fromX} fromY={pieceInfo.fromY} fromId={pieceInfo.fromId} placed={true} />);
-					spaces[id] = this.renderGameSpace(y,x,id,fromPiece);
-					spaces[pieceInfo.fromId] = this.renderGameSpace(pieceInfo.fromY,pieceInfo.fromX,pieceInfo.fromId,toPiece);
-					this.setState({spaces: spaces});
-					app.saveActiveGame();
-					//this.swapPieces(pieceInfo.fromId,id)
+					this.swapPieces(pieceInfo.fromId,id)
 					return;
 				}
 			}

--- a/src/components/sections/GameBoard.js
+++ b/src/components/sections/GameBoard.js
@@ -103,13 +103,22 @@ class GameBoard extends React.Component {
 	}
 	highlightSpace(id) {
 		this.setState({ highlighted: id });
+		this.resetSpace(id);
 	}
 	highlightByKeyboard() {
 		var spaceId = parseInt(this.state.selectedSpace);
+		if (!this.state.spaces[spaceId] || !this.state.spaces[spaceId].props.children) {
+			return;
+		}
 		this.highlightSpace(spaceId);
 	}
 	swapByKeyboard(fromId) {
 		var spaceId = parseInt(this.state.selectedSpace);
+		if (fromId == spaceId) {
+			this.setState({ highlighted: false });
+			this.resetSpace(fromId);
+			return;
+		}
 		this.swapPieces(fromId,spaceId);
 		this.highlightSpace(null);
 	}
@@ -293,7 +302,15 @@ class GameBoard extends React.Component {
 	swapPieces(fromId,toId) {
 		var app = this.props.app;
 		var spaces = this.state.spaces;
-		var toInfo = spaces[toId].props.children.props;
+		var toSpace = spaces[toId];
+
+		if (!toSpace.props.children) {
+			this.setState({ highlighted: false });
+			this.resetSpace(fromId);
+			return;
+		}
+		
+		var toInfo = toSpace.props.children.props;
 		var fromInfo = spaces[fromId].props.children.props;
 		var fromCoords = idToXy(fromId);
 		var toCoords = idToXy(toId);
@@ -433,6 +450,9 @@ class GameBoard extends React.Component {
 	resetSpace(id) {
 		var spaces = this.state.spaces;
 		var space = spaces[id];
+		if (!space) {
+			return;
+		}
 		spaces[id] = this.renderGameSpace(space.props.y,space.props.x,id,space.props.children);
 		this.setState({ spaces: spaces })
 	}

--- a/src/components/sections/GameBoard.js
+++ b/src/components/sections/GameBoard.js
@@ -11,6 +11,7 @@ class GameBoard extends React.Component {
 		super(props);
 		this.state = {
 			spaces: {},
+			highlighted: null,
 			selectedSpace: 1,
 			battleContent: (
 				<div className="row">
@@ -27,6 +28,10 @@ class GameBoard extends React.Component {
 		this.placePiece = this.placePiece.bind(this);
 		this.emptySpace = this.emptySpace.bind(this);
 		this.resetSpace = this.resetSpace.bind(this);
+		this.swapPieces = this.swapPieces.bind(this);
+		this.swapByKeyboard = this.swapByKeyboard.bind(this);
+		
+		this.highlightSpace = this.highlightSpace.bind(this);
 		this.placementArrowMove = this.placementArrowMove.bind(this);
 		this.openBattleModal = this.openBattleModal.bind(this);
 		this.closeBattleModal = this.closeBattleModal.bind(this);
@@ -95,6 +100,19 @@ class GameBoard extends React.Component {
 		var playerColor = app.tileRack.playerColor;
 		var targetSpace = app.tileSpaces[rank];
 		this.placePiece({ rank: rank, color: playerColor, tileSpace: targetSpace }, spaceId, false);
+	}
+	highlightSpace(id) {
+		console.log('highlight',id);
+		this.setState({ highlighted: id });
+	}
+	highlightByKeyboard() {
+		var spaceId = parseInt(this.state.selectedSpace);
+		this.highlightSpace(spaceId);
+	}
+	swapByKeyboard(fromId) {
+		var spaceId = parseInt(this.state.selectedSpace);
+		this.swapPieces(fromId,spaceId);
+		this.highlightSpace(null);
 	}
 	selectSpace(id) {
 		var playerColor = this.props.app.tileRack.playerColor;
@@ -273,6 +291,24 @@ class GameBoard extends React.Component {
 		this.setState({ spaces: spaces });
 		app.tileRack.resetCounts();
 	}
+	swapPieces(fromId,toId) {
+		var app = this.props.app;
+		var spaces = this.state.spaces;
+		var toInfo = spaces[toId].props.children.props;
+		var fromInfo = spaces[fromId].props.children.props;
+		var fromCoords = idToXy(fromId);
+		var toCoords = idToXy(toId);
+		
+		var fromPiece =  (<DragPiece color={fromInfo.color} rank={fromInfo.rank} fromX={toInfo.fromX} fromY={toInfo.fromY} fromId={toId} placed={true} />);
+		var toPiece =  (<DragPiece color={toInfo.color} rank={toInfo.rank} fromX={fromInfo.fromX} fromY={fromInfo.fromY} fromId={fromId} placed={true} />);
+
+		spaces[toId] = this.renderGameSpace(fromCoords.y,fromCoords.x,toId,fromPiece);
+		spaces[fromId] = this.renderGameSpace(toCoords.y,toCoords.x,fromId,toPiece);
+		
+		this.setState({spaces: spaces});
+		app.saveActiveGame();
+		
+	}
 	// 'id' in placePiece refers to the board square id
 	placePiece(pieceInfo,id,loading,moveInfo) {
 		var spaces = this.state.spaces;
@@ -301,6 +337,7 @@ class GameBoard extends React.Component {
 					spaces[pieceInfo.fromId] = this.renderGameSpace(pieceInfo.fromY,pieceInfo.fromX,pieceInfo.fromId,toPiece);
 					this.setState({spaces: spaces});
 					app.saveActiveGame();
+					//this.swapPieces(pieceInfo.fromId,id)
 					return;
 				}
 			}

--- a/src/components/widgets/GamePiece.js
+++ b/src/components/widgets/GamePiece.js
@@ -133,7 +133,7 @@ function DragPiece(props) {
 	if (props.rank) {
 		piece = PIECES[props.rank]
 	}
-	if (piece && !piece.move) {
+	if (piece && !piece.move && props.game.state.started) {
 		styles['cursor'] = 'not-allowed';
 	}
 	var wrapperClass = '';

--- a/src/components/widgets/GameSpace.js
+++ b/src/components/widgets/GameSpace.js
@@ -165,13 +165,17 @@ function DropSpace({ id, x, y, passable, board, game, children }) {
 			board.selectSpace(id);
 		}
 	}
+	var selectedClass = '';
 	var highlightClass = '';
 	if (!game.state.started && game.state.placementMode == 'keyboard' && board.state.selectedSpace == id) {
-		highlightClass = ' selectedSpace';
+		selectedClass = ' selectedSpace';
+	}
+	if (!game.state.started && game.state.placementMode == 'keyboard' && board.state.highlighted && board.state.highlighted == id) {
+		highlightClass = ' highlightedSpace';
 	}
 	var passableClass = passable ? ' passable' : ' not-passable';
 	return (
-		<div ref={drop} className={"gameSpace-wrapper col px-0 mx-0 "+spaceClass+highlightClass+passableClass} onClick={handleClick}>
+		<div ref={drop} className={"gameSpace-wrapper col px-0 mx-0 "+spaceClass+selectedClass+highlightClass+passableClass} onClick={handleClick}>
 			<div className="gameSpace-overlay"></div>
 			<GameSpace id={id} x={x} y={y} passable={passable} territory={territory} board={board}>
 				{children}

--- a/src/index.js
+++ b/src/index.js
@@ -670,6 +670,19 @@ class App extends React.Component {
 					this.activeModal.props.onKeyDown(e);
 				}
 			break;
+			case keyCodes['space']:
+				if (this.gameRef) {
+					var game = this.gameRef;
+					if (!game.state.started && game.state.placementMode == 'keyboard') {
+						if (this.gameBoard.state.highlighted) {
+							this.gameBoard.swapByKeyboard(this.gameBoard.state.highlighted);
+						}
+						else {
+							this.gameBoard.highlightByKeyboard();
+						}
+					}
+				}
+			break;
 		}
 	}
 	render() {


### PR DESCRIPTION
Allows swapping of tiles in keyboard mode, by first highlighting one spot by pressing space and then selecting another occupied square and pressing space.

Fixes visual glitch where flag and bomb tiles in pre-game mode showed the "not allowed" cursor.

Fixes issue with tile counts when swapping between tile rack and game board.

Fixes issue where tiles became undraggable after being swapped with another tile.